### PR TITLE
feat: return and compare logprobs

### DIFF
--- a/src/nanovllm/engine/sequence.py
+++ b/src/nanovllm/engine/sequence.py
@@ -27,6 +27,8 @@ class Sequence:
         self.temperature = sampling_params.temperature
         self.max_tokens = sampling_params.max_tokens
         self.ignore_eos = sampling_params.ignore_eos
+        self.logprobs = sampling_params.logprobs
+        self.completion_logprobs = [] if sampling_params.logprobs else None
 
     def __len__(self):
         return self.num_tokens

--- a/src/nanovllm/layers/sampler.py
+++ b/src/nanovllm/layers/sampler.py
@@ -6,6 +6,7 @@ class Sampler(nn.Module):
 
     def __init__(self):
         super().__init__()
+        self.return_logprobs = False
 
     @torch.compile
     def forward(self, logits: torch.Tensor, temperatures: torch.Tensor):
@@ -16,9 +17,17 @@ class Sampler(nn.Module):
         # To avoid division by zero, we can replace 0s with 1s in temperatures,
         # as they will be masked out later anyway.
         safe_temperatures = torch.where(greedy_mask, torch.ones_like(temperatures), temperatures)
-        
-        logits = logits.float().div_(safe_temperatures.unsqueeze(dim=1))
-        probs = torch.softmax(logits, dim=-1)
+
+        scaled_logits = logits.float().div_(safe_temperatures.unsqueeze(dim=1))
+        probs = torch.softmax(scaled_logits, dim=-1)
         sample_tokens = probs.div_(torch.empty_like(probs).exponential_(1).clamp_min_(1e-10)).argmax(dim=-1)
-        
-        return torch.where(greedy_mask, greedy_tokens, sample_tokens)
+
+        selected_tokens = torch.where(greedy_mask, greedy_tokens, sample_tokens)
+
+        if self.return_logprobs:
+            # Compute log probabilities for the selected tokens
+            log_probs = torch.nn.functional.log_softmax(logits.float(), dim=-1)
+            selected_logprobs = log_probs.gather(dim=-1, index=selected_tokens.unsqueeze(-1)).squeeze(-1)
+            return selected_tokens, selected_logprobs
+
+        return selected_tokens

--- a/src/nanovllm/sampling_params.py
+++ b/src/nanovllm/sampling_params.py
@@ -6,6 +6,7 @@ class SamplingParams:
     temperature: float = 1.0
     max_tokens: int = 64
     ignore_eos: bool = False
+    logprobs: bool = False
 
     def __post_init__(self):
         assert self.temperature >= 0.0, "temperature must be non-negative"

--- a/test_batch_invariance.py
+++ b/test_batch_invariance.py
@@ -16,29 +16,45 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(path)
     llm = LLM(path, enforce_eager=True, tensor_parallel_size=1)
 
-    # Use temperature=0 for greedy and deterministic output
-    sampling_params = SamplingParams(temperature=0, max_tokens=32)
+    # Use temperature=0 for greedy and deterministic output, with logprobs enabled
+    sampling_params = SamplingParams(temperature=0, max_tokens=32, logprobs=True)
 
     prompt = "Generate 100 random numbers. Go directly into it, don't say Sure and don't say here are numbers. Just start with a number."
     formatted_prompt = tokenizer.apply_chat_template(
         [{"role": "user", "content": prompt}],
         tokenize=False,
         add_generation_prompt=True,
+        enable_thinking=True
     )
 
     import random
 
     random.seed(42)
-    total_requests = 100
+    total_requests = 500
 
-    # Generate random batch sizes that sum to 100
+    # Generate random batch sizes that sum to total_requests with all unique values
     batch_sizes = []
     remaining = total_requests
+    used_sizes = set()
+
     while remaining > 0:
-        # Random batch size between 1 and min(10, remaining)
-        batch_size = random.randint(1, min(10, remaining))
-        batch_sizes.append(batch_size)
-        remaining -= batch_size
+        # Random batch size between 1 and min(30, remaining)
+        max_size = min(30, remaining)
+
+        # Try to find a unique batch size
+        attempts = 0
+        while attempts < 100:
+            batch_size = random.randint(1, max_size)
+            if batch_size not in used_sizes:
+                batch_sizes.append(batch_size)
+                used_sizes.add(batch_size)
+                remaining -= batch_size
+                break
+            attempts += 1
+        else:
+            # If we can't find a unique size after many attempts, just use remaining
+            batch_sizes.append(remaining)
+            remaining = 0
 
     print(f"Random batch sizes: {batch_sizes}")
     print(f"Total batches: {len(batch_sizes)}, Total requests: {sum(batch_sizes)}")
@@ -55,11 +71,14 @@ def main():
         start_time = time.time()
         all_outputs = []
 
+        all_logprobs = []
+
         with set_batch_invariant_mode(invariant_mode):
             for batch_idx, batch_size in enumerate(batch_sizes):
                 prompts = [formatted_prompt] * batch_size
                 results = llm.generate(prompts, sampling_params, use_tqdm=False)
                 all_outputs.extend([result['text'] for result in results])
+                all_logprobs.extend([tuple(result['logprobs']) if result['logprobs'] else None for result in results])
 
                 if (batch_idx + 1) % max(1, len(batch_sizes) // 10) == 0:
                     print(f"  Progress: {len(all_outputs)}/{total_requests} requests ({batch_idx + 1}/{len(batch_sizes)} batches)")
@@ -69,48 +88,65 @@ def main():
         # Save outputs
         mode_dir = os.path.join(output_dir, "with_invariance" if invariant_mode else "without_invariance")
         os.makedirs(mode_dir, exist_ok=True)
-        for i, output_text in enumerate(all_outputs):
+        for i, (output_text, logprobs) in enumerate(zip(all_outputs, all_logprobs)):
             with open(os.path.join(mode_dir, f"output_{i+1}.txt"), "w") as f:
                 f.write(output_text)
+            if logprobs:
+                with open(os.path.join(mode_dir, f"logprobs_{i+1}.txt"), "w") as f:
+                    f.write(str(logprobs))
 
-        # Analyze results
+        # Analyze results using logprobs (more precise than text comparison)
+        unique_logprobs = set(all_logprobs)
         unique_outputs = set(all_outputs)
 
         print(f"\nResults for {mode_name}:")
         print(f"  Time: {end_time - start_time:.2f}s")
         print(f"  Total samples: {len(all_outputs)}")
-        print(f"  Unique samples: {len(unique_outputs)}")
-        print(f"  Status: {'✓ PASS - All outputs identical' if len(unique_outputs) == 1 else f'✗ FAIL - Found {len(unique_outputs)} different outputs'}")
+        print(f"  Unique text outputs: {len(unique_outputs)}")
+        print(f"  Unique logprob sequences: {len(unique_logprobs)}")
+        print(f"  Status (by logprobs): {'✓ PASS - All outputs identical' if len(unique_logprobs) == 1 else f'✗ FAIL - Found {len(unique_logprobs)} different outputs'}")
 
         # Store results for comparison
         results_comparison[mode_name] = {
             'time': end_time - start_time,
-            'unique_count': len(unique_outputs),
+            'unique_text_count': len(unique_outputs),
+            'unique_logprobs_count': len(unique_logprobs),
             'outputs': all_outputs,
+            'logprobs': all_logprobs,
             'unique_outputs': unique_outputs
         }
 
-        # Print all different outputs
-        if len(unique_outputs) > 1:
-            print(f"\n  Different outputs for {mode_name}:")
+        # Print all different outputs with their logprobs
+        if len(unique_outputs) >= 1:
+            print(f"\n  Output details for {mode_name}:")
             for i, output in enumerate(unique_outputs, 1):
                 count = all_outputs.count(output)
+                # Find the corresponding logprobs for this output
+                output_idx = all_outputs.index(output)
+                corresponding_logprobs = all_logprobs[output_idx]
+
                 print(f"\n  Output #{i} (appeared {count} times):")
                 print("  " + "-" * 58)
-                print("  " + output[:100] + ("..." if len(output) > 100 else ""))
+                print("  Text: " + output[:200] + ("..." if len(output) > 200 else ""))
+                print("  Logprobs (first 10): " + str(corresponding_logprobs[:10]) + ("..." if len(corresponding_logprobs) > 10 else ""))
                 print("  " + "-" * 58)
 
+        # Print all unique logprob sequences if different from unique outputs
+        if len(unique_logprobs) > len(unique_outputs):
+            print(f"\n  Note: Found {len(unique_logprobs)} unique logprob sequences but only {len(unique_outputs)} unique text outputs")
+            print(f"  This means some outputs have identical text but different probability distributions")
+
     # Final comparison
-    print(f"\n{'='*60}")
+    print(f"\n{'='*80}")
     print("COMPARISON SUMMARY")
-    print(f"{'='*60}")
+    print(f"{'='*80}")
     print(f"Batch sizes used: {batch_sizes}")
     print()
-    print(f"{'Mode':<30} {'Unique Outputs':<20} {'Time (s)':<15} {'Status'}")
-    print("-" * 70)
+    print(f"{'Mode':<30} {'Unique Texts':<15} {'Unique Logprobs':<18} {'Time (s)':<12} {'Status'}")
+    print("-" * 80)
     for mode_name, results in results_comparison.items():
-        status = "PASS" if results['unique_count'] == 1 else "FAIL"
-        print(f"{mode_name:<30} {results['unique_count']:<20} {results['time']:<15.2f} {status}")
+        status = "PASS" if results['unique_logprobs_count'] == 1 else "FAIL"
+        print(f"{mode_name:<30} {results['unique_text_count']:<15} {results['unique_logprobs_count']:<18} {results['time']:<12.2f} {status}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
```
(nano-vllm) piyifan@BigPC:~/workspace/nano-vllm$ python3 test_batch_invariance.py 
`torch_dtype` is deprecated! Use `dtype` instead!
Random batch sizes: [21, 4, 1, 24, 9, 8, 5, 22, 29, 18, 3, 19, 14, 2, 7, 17, 20, 23, 15, 26, 28, 25, 6, 11, 13, 12, 30, 10, 27, 16, 35]
Total batches: 31, Total requests: 500

============================================================
Testing WITHOUT batch invariance
============================================================
  Progress: 26/500 requests (3/31 batches)
  Progress: 67/500 requests (6/31 batches)
  Progress: 123/500 requests (9/31 batches)
  Progress: 163/500 requests (12/31 batches)
  Progress: 186/500 requests (15/31 batches)
  Progress: 246/500 requests (18/31 batches)
  Progress: 315/500 requests (21/31 batches)
  Progress: 357/500 requests (24/31 batches)
  Progress: 412/500 requests (27/31 batches)
  Progress: 465/500 requests (30/31 batches)

Results for WITHOUT batch invariance:
  Time: 15.10s
  Total samples: 500
  Unique text outputs: 3
  Unique logprob sequences: 13
  Status (by logprobs): ✗ FAIL - Found 13 different outputs

  Output details for WITHOUT batch invariance:

  Output #1 (appeared 246 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.


  Logprobs (first 10): (-0.00032431588624604046, 0.0, -0.019978953525424004, -2.7894584491150454e-05, -0.36148011684417725, -0.00028046013903804123, -0.01682097464799881, -0.07049286365509033, -1.6927575416048057e-05, -0.0005208089714869857)...
  ----------------------------------------------------------

  Output #2 (appeared 9 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number without any explanation. Let me think about how to
  Logprobs (first 10): (-0.00032431588624604046, 0.0, -0.01785339042544365, -2.8371408916427754e-05, -0.3398931920528412, -0.00027700403006747365, -0.01728014089167118, -0.07050641626119614, -1.9073304429184645e-05, -0.000519617460668087)...
  ----------------------------------------------------------

  Output #3 (appeared 245 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number, not mention "Sure" or "here are
  Logprobs (first 10): (-0.00032228996860794723, 0.0, -0.01785339042544365, -3.123234637314454e-05, -0.361427366733551, -0.00031513971043750644, -0.017428696155548096, -0.07049141824245453, -1.6927575416048057e-05, -0.0005830018781125546)...
  ----------------------------------------------------------

  Note: Found 13 unique logprob sequences but only 3 unique text outputs
  This means some outputs have identical text but different probability distributions

============================================================
Testing WITH batch invariance
============================================================
/home/piyifan/workspace/nano-vllm/.venv/lib/python3.12/site-packages/torch/library.py:381: UserWarning: Warning only once for all operators,  other operators may also be overridden.
  Overriding a previously registered kernel for the same operator and the same dispatch key
  operator: aten::mm(Tensor self, Tensor mat2) -> Tensor
    registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
  dispatch key: CUDA
  previous kernel: registered at /pytorch/aten/src/ATen/LegacyBatchingRegistrations.cpp:1079
       new kernel: registered at /dev/null:502 (Triggered internally at /pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:218.)
  self.m.impl(
  Progress: 26/500 requests (3/31 batches)
  Progress: 67/500 requests (6/31 batches)
  Progress: 123/500 requests (9/31 batches)
  Progress: 163/500 requests (12/31 batches)
  Progress: 186/500 requests (15/31 batches)
  Progress: 246/500 requests (18/31 batches)
  Progress: 315/500 requests (21/31 batches)
  Progress: 357/500 requests (24/31 batches)
  Progress: 412/500 requests (27/31 batches)
  Progress: 465/500 requests (30/31 batches)

Results for WITH batch invariance:
  Time: 17.84s
  Total samples: 500
  Unique text outputs: 1
  Unique logprob sequences: 1
  Status (by logprobs): ✓ PASS - All outputs identical

  Output details for WITH batch invariance:

  Output #1 (appeared 500 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.


  Logprobs (first 10): (-0.0003177614707965404, 0.0, -0.017822593450546265, -2.47952248173533e-05, -0.3269926905632019, -0.00028224775451235473, -0.018815839663147926, -0.07958245277404785, -1.537788011773955e-05, -0.0005214046686887741)...
  ----------------------------------------------------------

================================================================================
COMPARISON SUMMARY
================================================================================
Batch sizes used: [21, 4, 1, 24, 9, 8, 5, 22, 29, 18, 3, 19, 14, 2, 7, 17, 20, 23, 15, 26, 28, 25, 6, 11, 13, 12, 30, 10, 27, 16, 35]

Mode                           Unique Texts    Unique Logprobs    Time (s)     Status
--------------------------------------------------------------------------------
WITHOUT batch invariance       3               13                 15.10        FAIL
WITH batch invariance          1               1                  17.84        PASS
```