### PR TITLE
chore: set longer max_tokens to promote more batch invariant problems

### DIFF
--- a/test_batch_invariance.py
+++ b/test_batch_invariance.py
@@ -17,7 +17,7 @@ def main():
     llm = LLM(path, enforce_eager=True, tensor_parallel_size=1)
 
     # Use temperature=0 for greedy and deterministic output, with logprobs enabled
-    sampling_params = SamplingParams(temperature=0, max_tokens=32, logprobs=True)
+    sampling_params = SamplingParams(temperature=0, max_tokens=1000, logprobs=True)
 
     prompt = "Generate 100 random numbers. Go directly into it, don't say Sure and don't say here are numbers. Just start with a number."
     formatted_prompt = tokenizer.apply_chat_template(
@@ -30,7 +30,7 @@ def main():
     import random
 
     random.seed(42)
-    total_requests = 500
+    total_requests = 100
 
     # Generate random batch sizes that sum to total_requests with all unique values
     batch_sizes = []


### PR DESCRIPTION
Now much easier to see diffs even in batch invariant mode (where we only have batch invariant ops from the tml repo which lacks of batch invariant FA now).

```
(nano-vllm) piyifan@BigPC:~/workspace/nano-vllm$ python3 test_batch_invariance.py 
`torch_dtype` is deprecated! Use `dtype` instead!
Random batch sizes: [21, 4, 1, 24, 9, 8, 5, 22, 6]
Total batches: 9, Total requests: 100

============================================================
Testing WITHOUT batch invariance
============================================================
  Progress: 21/100 requests (1/9 batches)
  Progress: 25/100 requests (2/9 batches)
  Progress: 26/100 requests (3/9 batches)
  Progress: 50/100 requests (4/9 batches)
  Progress: 59/100 requests (5/9 batches)
  Progress: 67/100 requests (6/9 batches)
  Progress: 72/100 requests (7/9 batches)
  Progress: 94/100 requests (8/9 batches)
  Progress: 100/100 requests (9/9 batches)

Results for WITHOUT batch invariance:
  Time: 116.28s
  Total samples: 100
  Unique text outputs: 8
  Unique logprob sequences: 9
  Status (by logprobs): ✗ FAIL - Found 9 different outputs

  Output details for WITHOUT batch invariance:

  Output #1 (appeared 11 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.

First, I need to make sure I'm generating numbers correctly. Sinc...
  Logprobs (first 10): (-0.0003215749457012862, 0.0, -0.01765875145792961, -2.95634672511369e-05, -0.36144688725471497, -0.00031740395934320986, -0.015543858520686626, -0.07050997018814087, -1.6927575416048057e-05, -0.0005845506675541401)...
  ----------------------------------------------------------

  Output #2 (appeared 1 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.

First, I need to make sure I'm generating numbers correctly. Sinc...
  Logprobs (first 10): (-0.0003237200144212693, 0.0, -0.017781605944037437, -2.8013790142722428e-05, -0.3251760005950928, -0.0002775999018922448, -0.016951197758316994, -0.07958344370126724, -1.5258672647178173e-05, -0.0005281960475258529)...
  ----------------------------------------------------------

  Output #3 (appeared 4 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number, not mention "Sure" or "here are numbers". Let me think about how to approach this.

First, I need to make s...
  Logprobs (first 10): (-0.00032228996860794723, 0.0, -0.01785339042544365, -3.123234637314454e-05, -0.361427366733551, -0.00031513971043750644, -0.017428696155548096, -0.07049141824245453, -1.6927575416048057e-05, -0.0005830018781125546)...
  ----------------------------------------------------------

  Output #4 (appeared 22 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.

First, I need to make sure I'm generating numbers correctly. Sinc...
  Logprobs (first 10): (-0.00032431588624604046, 0.0, -0.019978953525424004, -2.7894584491150454e-05, -0.36148011684417725, -0.00028046013903804123, -0.01682097464799881, -0.07049286365509033, -1.6927575416048057e-05, -0.0005208089714869857)...
  ----------------------------------------------------------

  Output #5 (appeared 24 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number, not mention "Sure" or "here are numbers". Let me think about how to approach this.

First, I need to make s...
  Logprobs (first 10): (-0.0003237200144212693, 0.0, -0.017569266259670258, -2.6225699912174605e-05, -0.33986952900886536, -0.00024625606602057815, -0.015207535587251186, -0.07958300411701202, -1.6927575416048057e-05, -0.0005758534534834325)...
  ----------------------------------------------------------

  Output #6 (appeared 9 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number without any explanation. Let me think about how to approach this.

First, I need to make sure I'm generating...
  Logprobs (first 10): (-0.00032431588624604046, 0.0, -0.01785339042544365, -2.8371408916427754e-05, -0.3398931920528412, -0.00027700403006747365, -0.01728014089167118, -0.07050641626119614, -1.9073304429184645e-05, -0.000519617460668087)...
  ----------------------------------------------------------

  Output #7 (appeared 8 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number, not mention "Sure" or "here are numbers". Let me think about how to approach this.

First, I need to make s...
  Logprobs (first 10): (-0.0003420721332076937, 0.0, -0.019933145493268967, -3.158996332786046e-05, -0.3528112769126892, -0.00028200942324474454, -0.016941703855991364, -0.0704999715089798, -1.5258672647178173e-05, -0.0005267662927508354)...
  ----------------------------------------------------------

  Output #8 (appeared 21 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.

First, I need to make sure I'm generating numbers correctly. Sinc...
  Logprobs (first 10): (-0.00032431588624604046, 0.0, -0.019978953525424004, -2.7894584491150454e-05, -0.36148011684417725, -0.00028046013903804123, -0.01682097464799881, -0.07049286365509033, -1.6927575416048057e-05, -0.0005208089714869857)...
  ----------------------------------------------------------

  Note: Found 9 unique logprob sequences but only 8 unique text outputs
  This means some outputs have identical text but different probability distributions

============================================================
Testing WITH batch invariance
============================================================
/home/piyifan/workspace/nano-vllm/.venv/lib/python3.12/site-packages/torch/library.py:381: UserWarning: Warning only once for all operators,  other operators may also be overridden.
  Overriding a previously registered kernel for the same operator and the same dispatch key
  operator: aten::mm(Tensor self, Tensor mat2) -> Tensor
    registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
  dispatch key: CUDA
  previous kernel: registered at /pytorch/aten/src/ATen/LegacyBatchingRegistrations.cpp:1079
       new kernel: registered at /dev/null:502 (Triggered internally at /pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:218.)
  self.m.impl(
  Progress: 21/100 requests (1/9 batches)
  Progress: 25/100 requests (2/9 batches)
  Progress: 26/100 requests (3/9 batches)
  Progress: 50/100 requests (4/9 batches)
  Progress: 59/100 requests (5/9 batches)
  Progress: 67/100 requests (6/9 batches)
  Progress: 72/100 requests (7/9 batches)
  Progress: 94/100 requests (8/9 batches)
  Progress: 100/100 requests (9/9 batches)

Results for WITH batch invariance:
  Time: 157.45s
  Total samples: 100
  Unique text outputs: 3
  Unique logprob sequences: 7
  Status (by logprobs): ✗ FAIL - Found 7 different outputs

  Output details for WITH batch invariance:

  Output #1 (appeared 46 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.

First, I need to make sure I'm generating random numbers correctl...
  Logprobs (first 10): (-0.0003177614707965404, 0.0, -0.017822593450546265, -2.47952248173533e-05, -0.3269926905632019, -0.00028224775451235473, -0.018815839663147926, -0.07958245277404785, -1.537788011773955e-05, -0.0005214046686887741)...
  ----------------------------------------------------------

  Output #2 (appeared 33 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.

First, I need to make sure I'm generating random numbers correctl...
  Logprobs (first 10): (-0.0003177614707965404, 0.0, -0.017822593450546265, -2.47952248173533e-05, -0.3269926905632019, -0.00028224775451235473, -0.018815839663147926, -0.07958245277404785, -1.537788011773955e-05, -0.0005214046686887741)...
  ----------------------------------------------------------

  Output #3 (appeared 21 times):
  ----------------------------------------------------------
  Text: <think>
Okay, the user wants me to generate 100 random numbers and just start with a number. Let me think about how to approach this.

First, I need to make sure I'm generating random numbers correctl...
  Logprobs (first 10): (-0.0003177614707965404, 0.0, -0.017822593450546265, -2.47952248173533e-05, -0.3269926905632019, -0.00028224775451235473, -0.018815839663147926, -0.07958245277404785, -1.537788011773955e-05, -0.0005214046686887741)...
  ----------------------------------------------------------

  Note: Found 7 unique logprob sequences but only 3 unique text outputs
  This means some outputs have identical text but different probability distributions

================================================================================
COMPARISON SUMMARY
================================================================================
Batch sizes used: [21, 4, 1, 24, 9, 8, 5, 22, 6]

Mode                           Unique Texts    Unique Logprobs    Time (s)     Status
--------------------------------------------------------------------------------
WITHOUT batch invariance       8               9                  116.28       FAIL
WITH batch invariance          3               7                  157.45       FAIL
```